### PR TITLE
Allow jpg/png directory prediction

### DIFF
--- a/howto_ocr/README.md
+++ b/howto_ocr/README.md
@@ -1,0 +1,20 @@
+# Water Meter OCR with OpenCV and CNN
+
+This folder contains a minimal example showing how to build a
+mechanical water meter digit recognizer using OpenCV for image
+preprocessing and a small CNN for classification.
+
+The example assumes that you have a dataset of cropped digit images.
+You can train the CNN using this dataset and then apply it to new
+photos of the meter.
+
+## Quick start
+
+1. Prepare digit images sorted into directories by label.
+2. Run `python water_meter_ocr.py --train /path/to/dataset` to train
+the model.
+3. Run `python water_meter_ocr.py --predict /path/to/image.jpg` to
+   read digits from a photo. If a directory is provided, all `.jpg`
+   and `.png` files inside will be processed in order.
+
+See the comments in `water_meter_ocr.py` for more details.

--- a/howto_ocr/water_meter_ocr.py
+++ b/howto_ocr/water_meter_ocr.py
@@ -1,0 +1,92 @@
+import argparse
+import os
+import glob
+import cv2
+import numpy as np
+from tensorflow import keras
+from tensorflow.keras import layers
+
+# Simple CNN model for digit recognition
+
+def build_model(input_shape=(28, 28, 1), num_classes=10):
+    model = keras.Sequential([
+        layers.Conv2D(32, (3, 3), activation='relu', input_shape=input_shape),
+        layers.MaxPooling2D((2, 2)),
+        layers.Conv2D(64, (3, 3), activation='relu'),
+        layers.MaxPooling2D((2, 2)),
+        layers.Flatten(),
+        layers.Dense(128, activation='relu'),
+        layers.Dense(num_classes, activation='softmax'),
+    ])
+    model.compile(optimizer='adam', loss='sparse_categorical_crossentropy',
+                  metrics=['accuracy'])
+    return model
+
+
+def train_model(dataset_path, model_path='digit_model.h5'):
+    """Train the CNN using images in dataset_path."""
+    data_gen = keras.preprocessing.image.ImageDataGenerator(rescale=1./255)
+    train_gen = data_gen.flow_from_directory(
+        dataset_path,
+        target_size=(28, 28),
+        color_mode='grayscale',
+        class_mode='sparse')
+
+    model = build_model()
+    model.fit(train_gen, epochs=5)
+    model.save(model_path)
+    print(f"model saved to {model_path}")
+
+
+def predict_digits(path, model_path='digit_model.h5'):
+    """Read digits from an image file or directory using a trained model."""
+    model = keras.models.load_model(model_path)
+
+    if os.path.isdir(path):
+        images = sorted(glob.glob(os.path.join(path, '*.jpg')) +
+                        glob.glob(os.path.join(path, '*.png')))
+        if not images:
+            print(f"No jpg or png images found in {path}")
+            return
+    else:
+        images = [path]
+
+    for image_path in images:
+        img = cv2.imread(image_path)
+        gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        _, th = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU)
+
+        contours, _ = cv2.findContours(th, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        digits = []
+        for cnt in sorted(contours, key=cv2.boundingRect):
+            x, y, w, h = cv2.boundingRect(cnt)
+            if h < 10 or w < 5:
+                continue
+            digit = th[y:y+h, x:x+w]
+            digit = cv2.resize(digit, (28, 28))
+            digit = digit.astype('float32') / 255.0
+            digit = np.expand_dims(digit, axis=-1)
+            digits.append((x, digit))
+
+        result = ''
+        for x, d in sorted(digits, key=lambda t: t[0]):
+            pred = model.predict(d[np.newaxis, ...])
+            result += str(np.argmax(pred))
+        print(f"{os.path.basename(image_path)}: {result}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--train', help='path to digit dataset')
+    parser.add_argument('--predict', help='path to image file or directory')
+    parser.add_argument('--model', default='digit_model.h5', help='model file')
+    args = parser.parse_args()
+
+    if args.train:
+        train_model(args.train, args.model)
+    if args.predict:
+        predict_digits(args.predict, args.model)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- expand `water_meter_ocr.py` to handle a directory of jpg/png images
- mention directory prediction in the OCR README

## Testing
- `python -m py_compile howto_ocr/water_meter_ocr.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683ae2c68d1c8322bc74c6a6ba45c5b9